### PR TITLE
Set Title of the images when single spawn list

### DIFF
--- a/map.js
+++ b/map.js
@@ -176,6 +176,7 @@ let SetSelectedDen = function(den)
                 box.classList.remove('sword-only','shield-only');
                 box.species1.removeAttribute('src');
                 box.species1.src = ('sprite/'+(spawnData.isGMax ? 'gmax_' : '')+spawnData.species+'.png');
+                box.species1.title = spawnData.species;
                 for (const [c,m] of STAR_CONTROLS)
                     box.classList.toggle(c,spawnData.stars === m);
             }


### PR DESCRIPTION
When the Spawn list is the same for both versions, we were forgetting to set/update the title of the images title to the corresponding pokemon that the image was updated to be.
This fixes #2